### PR TITLE
(feat) Restructured leaving group function

### DIFF
--- a/client/src/components/Group/LeaveGroupModal.jsx
+++ b/client/src/components/Group/LeaveGroupModal.jsx
@@ -4,6 +4,7 @@ import { defaults } from '../../redux/reducers/groupReducer'
 import { connect } from 'react-redux';
 import { Grid, Image, Button, Modal, Icon, Header } from 'semantic-ui-react';
 import { firebaseRemove, updateUserGroupID, updateGroup} from '../../redux/actions';
+import store from '../../redux/store'
 import { Link } from 'react-router-dom'
 
 class LeaveGroupModal extends Component {
@@ -62,6 +63,9 @@ function removeUserFromGroup(user) {
   updateGroup(defaults);
   firebaseRemove(`groups/${user.groupId}/memberKeys/${user.uid}`);
   firebaseRemove(`users/${user.uid}/groupId`);
+  if (Object.keys(store.getState().group.memberKeys).length === 0) {
+    firebaseRemove(`groups/${user.groupId}`)
+  }
 }
 
 export default connect((store) => {

--- a/client/src/components/Group/LeaveGroupModal.jsx
+++ b/client/src/components/Group/LeaveGroupModal.jsx
@@ -59,13 +59,13 @@ class LeaveGroupModal extends Component {
 }
 
 function removeUserFromGroup(user) {
-  updateUserGroupID('');
-  updateGroup(defaults);
   firebaseRemove(`groups/${user.groupId}/memberKeys/${user.uid}`);
-  firebaseRemove(`users/${user.uid}/groupId`);
-  if (Object.keys(store.getState().group.memberKeys).length === 0) {
+  if (Object.keys(store.getState().group.memberKeys).length === 1) {
     firebaseRemove(`groups/${user.groupId}`)
   }
+  firebaseRemove(`users/${user.uid}/groupId`);
+  updateUserGroupID('');
+  updateGroup(defaults);
 }
 
 export default connect((store) => {

--- a/client/src/redux/reducers/groupReducer.js
+++ b/client/src/redux/reducers/groupReducer.js
@@ -52,6 +52,7 @@ export default function groupReducer(state = defaults, action) {
       return newState;
     }
     case 'UPDATE_GROUP': {
+      console.log('payload', action.payload)
       return { ...state, ...action.payload.group }
     }
     case 'UPDATE_GROUP_NAME': {

--- a/client/src/redux/reducers/groupReducer.js
+++ b/client/src/redux/reducers/groupReducer.js
@@ -52,7 +52,6 @@ export default function groupReducer(state = defaults, action) {
       return newState;
     }
     case 'UPDATE_GROUP': {
-      console.log('payload', action.payload)
       return { ...state, ...action.payload.group }
     }
     case 'UPDATE_GROUP_NAME': {


### PR DESCRIPTION
Inserted logic to see if there are any remaining memberKeys after you leave a group. If not, the group is deleted from firebase to keep things clean.

(fix) Personal group state resets entirely upon leaving a group